### PR TITLE
[feat] GameManager 내에 저장 기능 임시 추가 / 자잘한 StageSelect fix

### DIFF
--- a/Assets/02.Scripts/StageScripts/Stagestate/SuccessState.cs
+++ b/Assets/02.Scripts/StageScripts/Stagestate/SuccessState.cs
@@ -11,10 +11,9 @@ public class SuccessState : IStageState
 
     public void Enter()
     {
-        Debug.Log("[Stage] Enter SuccessState -> FinalizeReward(Victory)");
-        
         SaveStageClearProgress();
 
+        Debug.Log("[Stage] Enter SuccessState -> FinalizeReward(Victory)");
         UIManager.Instance.OpenClear();
         _controller?.RewardHandler?.FinalizeReward(GameResult.Victory);
     }
@@ -27,21 +26,11 @@ public class SuccessState : IStageState
 
     private void SaveStageClearProgress()
     {
-        if (GameManager.Instance == null)
-        {
-            Debug.LogWarning("[SuccessState] GameManager is null. Clear progress not saved.");
-            return;
-        }
+        if (GameManager.Instance == null) return;
+        if (GameManager.Instance._currentStage == null) return;
 
         StageTable currentStage = GameManager.Instance._currentStage;
-        if (currentStage == null)
-        {
-            Debug.LogWarning("[SuccessState] CurrentStage is null. Clear progress not saved.");
-            return;
-        }
-
+        // RewardManager.Instance.SendToInventory(); 대충 이런거 보내야함.
         GameManager.Instance.MarkStageCleared(currentStage.tower_id, currentStage.stage_index);
-
-        Debug.Log($"[SuccessState] Stage clear saved. towerId={currentStage.tower_id}, stageIndex={currentStage.stage_index}");
     }
 }

--- a/Assets/02.Scripts/UI/StageSelect.cs
+++ b/Assets/02.Scripts/UI/StageSelect.cs
@@ -52,6 +52,9 @@ public class StageSelect : MonoBehaviour
         if (_contentRoot == null || _panelPrefab == null || _stageTableSO == null)
             return;
 
+        if (_scrollRect != null)
+            _scrollRect.verticalNormalizedPosition = 1f;
+
         ClearItems();
         BuildStageList();
         CreateItems();
@@ -149,7 +152,7 @@ public class StageSelect : MonoBehaviour
         return max;
     }
 
-    private int GetHighestUnlockedStageIndex()
+    private int GetFocusStageIndex()
     {
         int highestUnlocked = 0;
 
@@ -160,6 +163,11 @@ public class StageSelect : MonoBehaviour
                 highestUnlocked = Mathf.Max(highestUnlocked, _towerStages[i].stage_index);
             }
         }
+
+        // 현재 탑에 열린 스테이지가 하나도 없으면
+        // 잠긴 1스테이지를 기준으로 보여준다.
+        if (highestUnlocked <= 0)
+            return 1;
 
         return highestUnlocked;
     }
@@ -183,9 +191,8 @@ public class StageSelect : MonoBehaviour
 
         if (_scrollRect == null || _viewport == null || _spawnedPanels.Count == 0)
             yield break;
-
-        int highestUnlockedStage = GetHighestUnlockedStageIndex();
-        int panelIndex = GetPanelIndexByStageIndex(highestUnlockedStage);
+        int focusStageIndex = GetFocusStageIndex();
+        int panelIndex = GetPanelIndexByStageIndex(focusStageIndex);
 
         if (panelIndex < 0 || panelIndex >= _spawnedPanels.Count)
             yield break;

--- a/Assets/02.Scripts/Util/GameManager.cs
+++ b/Assets/02.Scripts/Util/GameManager.cs
@@ -22,9 +22,11 @@ public class GameManager : MonoBehaviour
     [SerializeField] private VoidEventChannelSO OnEnergyChange;
     private Dictionary<int, int> _maxClearStageIndexByTower = new Dictionary<int, int>();
 
+    private const string CLEAR_STAGE_KEY_PREFIX = "TowerClear_";
+
     private void Awake()
     {
-        if(instance != null && instance != this)
+        if (instance != null && instance != this)
         {
             Destroy(gameObject);
             return;
@@ -36,12 +38,14 @@ public class GameManager : MonoBehaviour
 
         DontDestroyOnLoad(gameObject);
         _maxEnergy = _energySystem.MaxEnergy;
-        //EnergyCount = _maxEnergy;
+        // EnergyCount = _maxEnergy;
+
+        LoadStageProgress();
     }
 
     public void EnterStage()
     {
-        if(_energySystem.IsStartInGame)
+        if (_energySystem.IsStartInGame)
         {
             UIManager.Instance.GoToStage();
         }
@@ -56,13 +60,13 @@ public class GameManager : MonoBehaviour
     public void SetCurrentStage(StageTable stage)
     {
         _currentStage = stage;
-        
-        if(stage != null)
+
+        if (stage != null)
         {
             _currentStageId = stage.stage_id;
             _currentStageIndex = stage.stage_index;
         }
-        else        
+        else
         {
             _currentStageId = 0;
             _currentStageIndex = 0;
@@ -72,28 +76,56 @@ public class GameManager : MonoBehaviour
     public int GetMaxClearStageIndex(int towerId)
     {
         if (_maxClearStageIndexByTower.TryGetValue(towerId, out int clearedIndex))
-        {
             return clearedIndex;
-        }
-        return 0; // 기본값은 0
-    }
 
-    public bool IsStageUnlocked(int towerId, int stageIndex)
-    {
-        // 모든 타워의 1스테이지는 항상 열림
-        if (stageIndex == 1)
-            return true;
-
-        int maxCleared = GetMaxClearStageIndex(towerId);
-        return stageIndex <= maxCleared + 1;
+        return 0;
     }
 
     public void MarkStageCleared(int towerId, int stageIndex)
     {
         int current = GetMaxClearStageIndex(towerId);
+
         if (stageIndex > current)
         {
             _maxClearStageIndexByTower[towerId] = stageIndex;
+            SaveTowerProgress(towerId, stageIndex);
+
+            Debug.Log($"[GameManager] Save Clear / towerId={towerId}, stageIndex={stageIndex}");
         }
-    }   
+    }
+
+    private void SaveTowerProgress(int towerId, int stageIndex)
+    {
+        PlayerPrefs.SetInt(CLEAR_STAGE_KEY_PREFIX + towerId, stageIndex);
+        PlayerPrefs.Save();
+    }
+
+    private void LoadStageProgress()
+    {
+        _maxClearStageIndexByTower.Clear();
+
+        // 임시: 현재 타워 범위만 하드코딩
+        for (int towerId = 5001; towerId <= 5007; towerId++)
+        {
+            int clearedIndex = PlayerPrefs.GetInt(CLEAR_STAGE_KEY_PREFIX + towerId, 0);
+
+            if (clearedIndex > 0)
+                _maxClearStageIndexByTower[towerId] = clearedIndex;
+
+            Debug.Log($"[GameManager] Load Clear / towerId={towerId}, stageIndex={clearedIndex}");
+        }
+    }
+
+    public void ClearStageProgress()
+    {
+        for (int towerId = 5001; towerId <= 5007; towerId++)
+        {
+            PlayerPrefs.DeleteKey(CLEAR_STAGE_KEY_PREFIX + towerId);
+        }
+
+        PlayerPrefs.Save();
+        _maxClearStageIndexByTower.Clear();
+
+        Debug.Log("[GameManager] Stage progress cleared.");
+    }
 }


### PR DESCRIPTION
GameManager 내에 PlayerPrefs로 저장 기능 임시 추가 및 SuccessState에서 클리어 기록 저장 및 GameManager로 전송하는 기능 추가, StageSelect 1번탑 2스테이지까지 클리어 후 2번탑(모두 잠겨있는 탑) 선택 시 1번 스테이지 보여주지 않던 문제 로직 수정